### PR TITLE
Disambiguation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Protocole d'échange pour messagerie instantanée permettant de coordonner un d�
 |:----------------- |:------------- |
 | 🔸                | Prêt pour partir, en attente d’un départ. |
 | 🔹 [Hx] hh:mm / N | Départ effectif, heure et nombre de personnes. Destination optionnelle, H1 la plupart du temps. |
-| ◾️ hh:mm          | Confirmation d’arrivée à destination. |
+| 🔚 hh:mm          | Confirmation d’arrivée à destination. |
 | 🔻                | Absent ou ne participant pas au repas collectif. |
 | 🔜                |Présent mais départ différé ou indépendant. Déplacement à la destination de manière autonome. Place à réserver. |
 


### PR DESCRIPTION
## Position du problème

L'un des objectifs principaux de ce protocole est d'annoncer sans ambiguïté les étapes de transhumance méridiennes.
J'ai le sentiment que certains signes choisis sont sujet à confusion, notamment dans la mesure où le glyph employé pour représenter le caractère unicode n'est pas homogène (et est même libre) en fonction des plateformes utilisées. 

## Signes incriminés dans la version actuelle

Le symbole ◼ `black_medium_small_square` [Unicode Codepoint U+25FE](https://emojipedia.org/black-medium-small-square/), signifiant "bien arrivés", est, en l'état, confondable avec le symbole 🔲 `black_square_button` [Unicode Codepoint  U+1F532](https://emojipedia.org/black-square-button/) signifiant "restaurant 'Le Carré'"

## Proposition de résolution

Je propose de substituer le symbole 🔚 `end_arrow` [Unicode Codepoints U+1F51A](https://emojipedia.org/end-with-leftwards-arrow-above/) en lieu et place de `black_medium_small_square` pour l'événement "arrivé à destination"